### PR TITLE
Additional profile handling

### DIFF
--- a/local_equivalent.py
+++ b/local_equivalent.py
@@ -236,6 +236,10 @@ def main():
         centos_yum_preinstall = []
     else:
         centos_yum_preinstall = list(args.centos_yum_preinstall)
+    if not args.additional_profiles_for_all_platforms:
+        additional_profiles_for_all_platforms = []
+    else:
+        additional_profiles_for_all_platforms = list(args.additional_profiles_for_all_platforms)
     try:
         build_conan_package(
             package=args.package,
@@ -253,6 +257,7 @@ def main():
             conan_logging_level=args.conan_logging_level,
             workaround_autotools_windows_debug_issue=args.workaround_autotools_windows_debug_issue,
             use_release_zlib_profile=args.use_release_zlib_profile,
+            additional_profiles_for_all_platforms=additional_profiles_for_all_platforms,
             really_upload=args.really_upload,
         )
     except subprocess.CalledProcessError as e:

--- a/local_equivalent.py
+++ b/local_equivalent.py
@@ -57,6 +57,7 @@ def build_conan_package(package, package_version, local_recipe, platform,
                         conan_logging_level='info',
                         workaround_autotools_windows_debug_issue=False,
                         use_release_zlib_profile=False,
+                        additional_profiles_for_all_platforms=[],
                         really_upload=False,
                         ):
 
@@ -138,6 +139,7 @@ def build_conan_package(package, package_version, local_recipe, platform,
 
     for build_type in build_types:
         additional_profiles = []
+        additional_profiles.extend(additional_profiles_for_all_platforms)
         if use_release_zlib_profile:
             if 'msvc16' in conan_profile:
                 additional_profiles.append('windows-msvc16-release-zlib')
@@ -215,6 +217,8 @@ def main():
         '--workaround-autotools-windows-debug-issue', help='', action='store_true')
     parser.add_argument('--use-release-zlib-profile',
                         help='', action='store_true')
+    parser.add_argument('--additional-profiles-for-all-platforms',
+                        help='Use additional profiles', action='append')
     parser.add_argument(
         '--local-recipe', help='directory that contains conanfile.py')
     parser.add_argument(

--- a/local_equivalent.py
+++ b/local_equivalent.py
@@ -59,6 +59,7 @@ def build_conan_package(package, package_version, local_recipe, platform,
                         use_release_zlib_profile=False,
                         additional_profiles_for_all_platforms=[],
                         really_upload=False,
+                        require_overrides=[]
                         ):
 
     # conan_env['CONAN_LOGGING_LEVEL']='critical'
@@ -160,6 +161,8 @@ def build_conan_package(package, package_version, local_recipe, platform,
             '-s',
             f'build_type={ build_type }',
         ]
+        for override in require_overrides:
+            conan_install_args += ['--require-override', override]
         run_conan(conan_install_args)
 
         if local_recipe:
@@ -223,6 +226,8 @@ def main():
         '--local-recipe', help='directory that contains conanfile.py')
     parser.add_argument(
         '--really-upload', help='really upload to artifactory', action='store_true')
+    parser.add_argument('--require-override',
+                        help='override requirements for specific package', action='append')
     args = parser.parse_args()
     if not args.build_types:
         build_types = ['Release', 'Debug', 'RelWithDebInfo']
@@ -240,6 +245,10 @@ def main():
         additional_profiles_for_all_platforms = []
     else:
         additional_profiles_for_all_platforms = list(args.additional_profiles_for_all_platforms)
+    if not args.require_override:
+        require_overrides = []
+    else:
+        require_overrides = list(args.require_override)
     try:
         build_conan_package(
             package=args.package,
@@ -259,6 +268,7 @@ def main():
             use_release_zlib_profile=args.use_release_zlib_profile,
             additional_profiles_for_all_platforms=additional_profiles_for_all_platforms,
             really_upload=args.really_upload,
+            require_overrides=require_overrides
         )
     except subprocess.CalledProcessError as e:
         print(f'Last command output was {e.output.decode(errors="replace")}')

--- a/single-build.yml
+++ b/single-build.yml
@@ -129,14 +129,23 @@ steps:
       scriptSource: 'inline'
       pythonInterpreter: ${{ parameters.python }}
       script: |
-        use_release_zlib_profile = ${{ parameters.use_release_zlib_profile }}
         profile = '${{ parameters.profile }}'
+        print(f'profile={profile}')
+
         build_type = '${{ build_type }}'
-        additional_profiles = '${{ parameters.additional_profiles_for_all_platforms }}'.split(',')
+        print(f'build_type={build_type}')
+
+        use_release_zlib_profile = ${{ parameters.use_release_zlib_profile }}
+        print(f'use_release_zlib_profile={use_release_zlib_profile}')
+
+        additional_profiles_for_all_platforms = '${{ parameters.additional_profiles_for_all_platforms }}'
+        print(f'additional_profiles_for_all_platforms={additional_profiles_for_all_platforms}')
+        additional_profiles = additional_profiles_for_all_platforms.split(',')
 
         if use_release_zlib_profile:
           if 'msvc16' in profile:
             additional_profiles.append('windows-msvc16-release-zlib')
+        print(f'additional_profiles={additional_profiles}')
 
         value = ' '.join([f'--profile {p}' for p in additional_profiles])
         print(f'##vso[task.setvariable variable=additional_profiles;]{value}')

--- a/single-build.yml
+++ b/single-build.yml
@@ -35,6 +35,9 @@ parameters:
   - name: use_release_zlib_profile
     type: boolean
     default: false
+  - name: additional_profiles_for_all_platforms
+    type: string
+    default: ''
 
 steps:
 - script: ${{ parameters.python }} -m pip install --upgrade conan
@@ -129,7 +132,7 @@ steps:
         use_release_zlib_profile = ${{ parameters.use_release_zlib_profile }}
         profile = '${{ parameters.profile }}'
         build_type = '${{ build_type }}'
-        additional_profiles = []
+        additional_profiles = ','.split('${{ parameters.additional_profiles_for_all_platforms }}')
 
         if use_release_zlib_profile:
           if 'msvc16' in profile:

--- a/single-build.yml
+++ b/single-build.yml
@@ -140,7 +140,10 @@ steps:
 
         additional_profiles_for_all_platforms = '${{ parameters.additional_profiles_for_all_platforms }}'
         print(f'additional_profiles_for_all_platforms={additional_profiles_for_all_platforms}')
-        additional_profiles = additional_profiles_for_all_platforms.split(',')
+        if additional_profiles_for_all_platforms:
+          additional_profiles = additional_profiles_for_all_platforms.split(',')
+        else:
+          additional_profiles = []
 
         if use_release_zlib_profile:
           if 'msvc16' in profile:

--- a/single-build.yml
+++ b/single-build.yml
@@ -132,7 +132,7 @@ steps:
         use_release_zlib_profile = ${{ parameters.use_release_zlib_profile }}
         profile = '${{ parameters.profile }}'
         build_type = '${{ build_type }}'
-        additional_profiles = ','.split('${{ parameters.additional_profiles_for_all_platforms }}')
+        additional_profiles = '${{ parameters.additional_profiles_for_all_platforms }}'.split(',')
 
         if use_release_zlib_profile:
           if 'msvc16' in profile:

--- a/single-local-recipe-build.yml
+++ b/single-local-recipe-build.yml
@@ -126,7 +126,10 @@ steps:
 
         additional_profiles_for_all_platforms = '${{ parameters.additional_profiles_for_all_platforms }}'
         print(f'additional_profiles_for_all_platforms={additional_profiles_for_all_platforms}')
-        additional_profiles = additional_profiles_for_all_platforms.split(',')
+        if additional_profiles_for_all_platforms:
+          additional_profiles = additional_profiles_for_all_platforms.split(',')
+        else:
+          additional_profiles = []
 
         if use_release_zlib_profile:
           if 'msvc16' in profile:

--- a/single-local-recipe-build.yml
+++ b/single-local-recipe-build.yml
@@ -35,6 +35,9 @@ parameters:
   - name: use_release_zlib_profile
     type: boolean
     default: false
+  - name: additional_profiles_for_all_platforms
+    type: string
+    default: ''
 
 steps:
 - script: ${{ parameters.python }} -m pip install --upgrade conan
@@ -115,7 +118,7 @@ steps:
         use_release_zlib_profile = ${{ parameters.use_release_zlib_profile }}
         profile = '${{ parameters.profile }}'
         build_type = '${{ build_type }}'
-        additional_profiles = []
+        additional_profiles = ','.split('${{ parameters.additional_profiles_for_all_platforms }}')
 
         if use_release_zlib_profile:
           if 'msvc16' in profile:

--- a/single-local-recipe-build.yml
+++ b/single-local-recipe-build.yml
@@ -115,14 +115,23 @@ steps:
       scriptSource: 'inline'
       pythonInterpreter: ${{ parameters.python }}
       script: |
-        use_release_zlib_profile = ${{ parameters.use_release_zlib_profile }}
         profile = '${{ parameters.profile }}'
+        print(f'profile={profile}')
+
         build_type = '${{ build_type }}'
-        additional_profiles = '${{ parameters.additional_profiles_for_all_platforms }}'.split(',')
+        print(f'build_type={build_type}')
+
+        use_release_zlib_profile = ${{ parameters.use_release_zlib_profile }}
+        print(f'use_release_zlib_profile={use_release_zlib_profile}')
+
+        additional_profiles_for_all_platforms = '${{ parameters.additional_profiles_for_all_platforms }}'
+        print(f'additional_profiles_for_all_platforms={additional_profiles_for_all_platforms}')
+        additional_profiles = additional_profiles_for_all_platforms.split(',')
 
         if use_release_zlib_profile:
           if 'msvc16' in profile:
             additional_profiles.append('windows-msvc16-release-zlib')
+        print(f'additional_profiles={additional_profiles}')
 
         value = ' '.join([f'--profile {p}' for p in additional_profiles])
         print(f'##vso[task.setvariable variable=additional_profiles;]{value}')

--- a/single-local-recipe-build.yml
+++ b/single-local-recipe-build.yml
@@ -118,7 +118,7 @@ steps:
         use_release_zlib_profile = ${{ parameters.use_release_zlib_profile }}
         profile = '${{ parameters.profile }}'
         build_type = '${{ build_type }}'
-        additional_profiles = ','.split('${{ parameters.additional_profiles_for_all_platforms }}')
+        additional_profiles = '${{ parameters.additional_profiles_for_all_platforms }}'.split(',')
 
         if use_release_zlib_profile:
           if 'msvc16' in profile:

--- a/third-party-library-all-platforms-from-conan-center.yml
+++ b/third-party-library-all-platforms-from-conan-center.yml
@@ -62,6 +62,9 @@ parameters:
   - name: use_release_zlib_profile
     type: boolean
     default: false
+  - name: additional_profiles_for_all_platforms
+    type: string
+    default: ''
 
 variables:
   ${{ if not(contains(parameters.package_version, '@')) }}:
@@ -97,6 +100,7 @@ jobs:
           conan_logging_level: ${{ parameters.conan_logging_level }}
           artifactory_service_connection: ${{ parameters.artifactory_service_connection }}
           use_release_zlib_profile: ${{ parameters.use_release_zlib_profile }}
+          additional_profiles_for_all_platforms: ${{ parameters.additional_profiles_for_all_platforms }}
 
 - ${{ if containsValue(parameters.platforms, 'centos7_gcc10') }}:
   - job: centos7_gcc10
@@ -125,6 +129,7 @@ jobs:
           conan_logging_level: ${{ parameters.conan_logging_level }}
           artifactory_service_connection: ${{ parameters.artifactory_service_connection }}
           use_release_zlib_profile: ${{ parameters.use_release_zlib_profile }}
+          additional_profiles_for_all_platforms: ${{ parameters.additional_profiles_for_all_platforms }}
 
 - ${{ if containsValue(parameters.platforms, 'ubuntu2004_gcc10') }}:
   - job: ubuntu2004_gcc10
@@ -148,6 +153,7 @@ jobs:
           conan_logging_level: ${{ parameters.conan_logging_level }}
           artifactory_service_connection: ${{ parameters.artifactory_service_connection }}
           use_release_zlib_profile: ${{ parameters.use_release_zlib_profile }}
+          additional_profiles_for_all_platforms: ${{ parameters.additional_profiles_for_all_platforms }}
 
 - ${{ if containsValue(parameters.platforms, 'macos1015_xcode11') }}:
   - job: macos1015_xcode11
@@ -182,6 +188,7 @@ jobs:
           conan_logging_level: ${{ parameters.conan_logging_level }}
           artifactory_service_connection: ${{ parameters.artifactory_service_connection }}
           use_release_zlib_profile: ${{ parameters.use_release_zlib_profile }}
+          additional_profiles_for_all_platforms: ${{ parameters.additional_profiles_for_all_platforms }}
 
 - ${{ if containsValue(parameters.platforms, 'macos1015_xcode12') }}:
   - job: macos1015_xcode12
@@ -216,6 +223,7 @@ jobs:
           conan_logging_level: ${{ parameters.conan_logging_level }}
           artifactory_service_connection: ${{ parameters.artifactory_service_connection }}
           use_release_zlib_profile: ${{ parameters.use_release_zlib_profile }}
+          additional_profiles_for_all_platforms: ${{ parameters.additional_profiles_for_all_platforms }}
 
 - ${{ if containsValue(parameters.platforms, 'win2019_vs2019') }}:
   - job: win2019_vs2019
@@ -242,6 +250,7 @@ jobs:
           workaround_autotools_windows_debug_issue: ${{ parameters.workaround_autotools_windows_debug_issue }}
           artifactory_service_connection: ${{ parameters.artifactory_service_connection }}
           use_release_zlib_profile: ${{ parameters.use_release_zlib_profile }}
+          additional_profiles_for_all_platforms: ${{ parameters.additional_profiles_for_all_platforms }}
 
 - ${{ if containsValue(parameters.platforms, 'win2019_msys') }}:
   - job: win2019_msys
@@ -268,3 +277,4 @@ jobs:
           workaround_autotools_windows_debug_issue: ${{ parameters.workaround_autotools_windows_debug_issue }}
           artifactory_service_connection: ${{ parameters.artifactory_service_connection }}
           use_release_zlib_profile: ${{ parameters.use_release_zlib_profile }}
+          additional_profiles_for_all_platforms: ${{ parameters.additional_profiles_for_all_platforms }}

--- a/third-party-library-all-platforms-from-local-recipe-split.yml
+++ b/third-party-library-all-platforms-from-local-recipe-split.yml
@@ -62,6 +62,9 @@ parameters:
   - name: use_release_zlib_profile
     type: boolean
     default: false
+  - name: additional_profiles_for_all_platforms
+    type: string
+    default: ''
 
 jobs:
 - ${{ if containsValue(parameters.platforms, 'centos7_gcc9') }}:
@@ -93,6 +96,7 @@ jobs:
             conan_logging_level: ${{ parameters.conan_logging_level }}
             artifactory_service_connection: ${{ parameters.artifactory_service_connection }}
             use_release_zlib_profile: ${{ parameters.use_release_zlib_profile }}
+           additional_profiles_for_all_platforms: ${{ parameters.additional_profiles_for_all_platforms }}
 
 - ${{ if containsValue(parameters.platforms, 'centos7_gcc10') }}:
   - ${{ each build_type in parameters.build_types }}: # Each build_type
@@ -123,6 +127,7 @@ jobs:
             conan_logging_level: ${{ parameters.conan_logging_level }}
             artifactory_service_connection: ${{ parameters.artifactory_service_connection }}
             use_release_zlib_profile: ${{ parameters.use_release_zlib_profile }}
+            additional_profiles_for_all_platforms: ${{ parameters.additional_profiles_for_all_platforms }}
 
 - ${{ if containsValue(parameters.platforms, 'ubuntu2004_gcc10') }}:
   - ${{ each build_type in parameters.build_types }}: # Each build_type
@@ -148,6 +153,7 @@ jobs:
             conan_logging_level: ${{ parameters.conan_logging_level }}
             artifactory_service_connection: ${{ parameters.artifactory_service_connection }}
             use_release_zlib_profile: ${{ parameters.use_release_zlib_profile }}
+            additional_profiles_for_all_platforms: ${{ parameters.additional_profiles_for_all_platforms }}
 
 - ${{ if containsValue(parameters.platforms, 'macos1015_xcode11') }}:
   - ${{ each build_type in parameters.build_types }}: # Each build_type
@@ -184,6 +190,7 @@ jobs:
             conan_logging_level: ${{ parameters.conan_logging_level }}
             artifactory_service_connection: ${{ parameters.artifactory_service_connection }}
             use_release_zlib_profile: ${{ parameters.use_release_zlib_profile }}
+            additional_profiles_for_all_platforms: ${{ parameters.additional_profiles_for_all_platforms }}
 
 - ${{ if containsValue(parameters.platforms, 'macos1015_xcode12') }}:
   - ${{ each build_type in parameters.build_types }}: # Each build_type
@@ -220,6 +227,7 @@ jobs:
             conan_logging_level: ${{ parameters.conan_logging_level }}
             artifactory_service_connection: ${{ parameters.artifactory_service_connection }}
             use_release_zlib_profile: ${{ parameters.use_release_zlib_profile }}
+            additional_profiles_for_all_platforms: ${{ parameters.additional_profiles_for_all_platforms }}
 
 - ${{ if containsValue(parameters.platforms, 'win2019_vs2019') }}:
   - ${{ each build_type in parameters.build_types }}: # Each build_type
@@ -248,6 +256,7 @@ jobs:
             workaround_autotools_windows_debug_issue: ${{ parameters.workaround_autotools_windows_debug_issue }}
             artifactory_service_connection: ${{ parameters.artifactory_service_connection }}
             use_release_zlib_profile: ${{ parameters.use_release_zlib_profile }}
+            additional_profiles_for_all_platforms: ${{ parameters.additional_profiles_for_all_platforms }}
 
 - ${{ if containsValue(parameters.platforms, 'win2019_msys') }}:
   - ${{ each build_type in parameters.build_types }}: # Each build_type
@@ -276,3 +285,4 @@ jobs:
             workaround_autotools_windows_debug_issue: ${{ parameters.workaround_autotools_windows_debug_issue }}
             artifactory_service_connection: ${{ parameters.artifactory_service_connection }}
             use_release_zlib_profile: ${{ parameters.use_release_zlib_profile }}
+            additional_profiles_for_all_platforms: ${{ parameters.additional_profiles_for_all_platforms }}

--- a/third-party-library-all-platforms-from-local-recipe.yml
+++ b/third-party-library-all-platforms-from-local-recipe.yml
@@ -62,6 +62,9 @@ parameters:
   - name: use_release_zlib_profile
     type: boolean
     default: false
+  - name: additional_profiles_for_all_platforms
+    type: string
+    default: ''
 
 jobs:
 - ${{ if containsValue(parameters.platforms, 'centos7_gcc9') }}:
@@ -91,7 +94,8 @@ jobs:
           conan_logging_level: ${{ parameters.conan_logging_level }}
           artifactory_service_connection: ${{ parameters.artifactory_service_connection }}
           use_release_zlib_profile: ${{ parameters.use_release_zlib_profile }}
-          
+          additional_profiles_for_all_platforms: ${{ parameters.additional_profiles_for_all_platforms }}
+
 - ${{ if containsValue(parameters.platforms, 'centos7_gcc10') }}:
   - job: centos7_gcc10
     pool:
@@ -119,6 +123,7 @@ jobs:
           conan_logging_level: ${{ parameters.conan_logging_level }}
           artifactory_service_connection: ${{ parameters.artifactory_service_connection }}
           use_release_zlib_profile: ${{ parameters.use_release_zlib_profile }}
+          additional_profiles_for_all_platforms: ${{ parameters.additional_profiles_for_all_platforms }}
           
 - ${{ if containsValue(parameters.platforms, 'ubuntu2004_gcc10') }}:
   - job: ubuntu2004_gcc10
@@ -142,6 +147,7 @@ jobs:
           conan_logging_level: ${{ parameters.conan_logging_level }}
           artifactory_service_connection: ${{ parameters.artifactory_service_connection }}
           use_release_zlib_profile: ${{ parameters.use_release_zlib_profile }}
+          additional_profiles_for_all_platforms: ${{ parameters.additional_profiles_for_all_platforms }}
 
 - ${{ if containsValue(parameters.platforms, 'macos1015_xcode11') }}:
   - job: macos1015_xcode11
@@ -176,6 +182,7 @@ jobs:
           conan_logging_level: ${{ parameters.conan_logging_level }}
           artifactory_service_connection: ${{ parameters.artifactory_service_connection }}
           use_release_zlib_profile: ${{ parameters.use_release_zlib_profile }}
+          additional_profiles_for_all_platforms: ${{ parameters.additional_profiles_for_all_platforms }}
 
 - ${{ if containsValue(parameters.platforms, 'macos1015_xcode12') }}:
   - job: macos1015_xcode12
@@ -210,6 +217,7 @@ jobs:
           conan_logging_level: ${{ parameters.conan_logging_level }}
           artifactory_service_connection: ${{ parameters.artifactory_service_connection }}
           use_release_zlib_profile: ${{ parameters.use_release_zlib_profile }}
+          additional_profiles_for_all_platforms: ${{ parameters.additional_profiles_for_all_platforms }}
 
 - ${{ if containsValue(parameters.platforms, 'win2019_vs2019') }}:
   - job: win2019_vs2019
@@ -236,6 +244,7 @@ jobs:
           workaround_autotools_windows_debug_issue: ${{ parameters.workaround_autotools_windows_debug_issue }}
           artifactory_service_connection: ${{ parameters.artifactory_service_connection }}
           use_release_zlib_profile: ${{ parameters.use_release_zlib_profile }}
+          additional_profiles_for_all_platforms: ${{ parameters.additional_profiles_for_all_platforms }}
 
 - ${{ if containsValue(parameters.platforms, 'win2019_msys') }}:
   - job: win2019_msys
@@ -262,3 +271,4 @@ jobs:
           workaround_autotools_windows_debug_issue: ${{ parameters.workaround_autotools_windows_debug_issue }}
           artifactory_service_connection: ${{ parameters.artifactory_service_connection }}
           use_release_zlib_profile: ${{ parameters.use_release_zlib_profile }}
+          additional_profiles_for_all_platforms: ${{ parameters.additional_profiles_for_all_platforms }}


### PR DESCRIPTION
- Add ability to pass additional profiles to builds: this is useful for things like 'I want to always use release zlib regardless of build type'
- Add ability to override a requirement for a specific package in local_equivalent. This ability is not yet in the yml files as it's not necessarily required. This may be useful when the conan center recipe is lagging behind with dependencies.